### PR TITLE
[ZD#672511] When using percent sign in Notes field, prevent request and show validation error modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -211,11 +211,14 @@
     },
 
     submitHours: function() {
-      var field, form = this.$('.hours form'), name, options = {}, passed = true, self = this;
+      var field, name, errorMessage,
+          form = this.$('.hours form'),
+          options = {},
+          passed = true,
+          self = this;
 
       form.find(':input')
           .not(':button, :submit, :reset, :hidden')
-          .not('textarea')
           .each(function(index, el) {
             field = self.$(el);
             name = field.attr('name');
@@ -230,26 +233,21 @@
               };
               var translationName = fieldNameToTranslationName[fieldName];
               var translatedFieldName = self.I18n.t("form." + translationName);
-              var errorMessage  = self.I18n.t('form.empty', { field: translatedFieldName });
-
-              var modalId = _.uniqueId();
-              var modal = self.renderTemplate('validation_modal', {
-                errorMessage: errorMessage,
-                id: modalId
-              });
-
-              field.parent().append(modal);
-              self.$('#'+ modalId).modal();
-
+              errorMessage  = self.I18n.t('form.empty', { field: translatedFieldName });
+              self.showValidationModal(field, errorMessage);
               passed = false;
-              return false;
+            }
+
+            if (field.val().indexOf("%") != -1 && name === 'notes') {
+              errorMessage  = self.I18n.t('form.notes_contains_percent_sign');
+              self.showValidationModal(field, errorMessage);
+              passed = false;
             }
 
             options[name] = field.val();
           });
 
-      if (!passed)
-        return false;
+      if (!passed) { return false; }
 
       options.staff_id = this.store('memberID');
       options.notes = form.find('.notes').val();
@@ -361,6 +359,17 @@
                                     this.I18n.t('invalidResponse') :
                                     this.I18n.t('problem', { error: errorThrown.toString() });
       this.showError(message);
+    },
+
+    showValidationModal: function(field, errorMessage) {
+      var modalId = _.uniqueId(),
+          modal = this.renderTemplate('validation_modal', {
+            errorMessage: errorMessage,
+            id: modalId
+          });
+
+      field.parent().append(modal);
+      this.$('#'+ modalId).modal();
     },
 
     showError: function(msg) {

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -78,6 +78,10 @@ parts:
       title: "This is a notes fields label"
       value: "Notes"
   - translation:
+      key: "txt.apps.freshbooks_app.form.notes_contains_percent_sign"
+      title: "This will declare that the notes field contains the percent sign."
+      value: "The Notes field cannot contain the percent sign ('%')"
+  - translation:
       key: "txt.apps.freshbooks_app.form.select_project"
       title: "This is a project dropdown this is the title of that dropdown"
       value: "Project"


### PR DESCRIPTION
Users receive 500 error message when submitting input containing the percent sign.
Solution: URI encode that input.
Problems:  It doesn't look so good on the other end (FreshBooks isn't decoding the notes data)
Solution: Can we ask Freshbooks to do this?  Or, maybe it would be better to simply surface en error message indicating why the user's input is not permitted (or at least specifying which chars are prohibited)

Also, noticed that error message links for failed requests are broken.  We could link to the relevant forum entry, using 'txt.apps.freshbooks_app.error.see_topic' or something similar

@maximeprades, is this your area?  Or is there someone else I should talk to? 

cc/ @pdeuter 
